### PR TITLE
removed forced 'missing ="fiml"'

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,1 @@
+.travis.yml

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 ### ezCutoffs 1.0.1
 
 <ul>
-  <li>missing_data = "missing" now also works correctly when not using missing = "fiml" estimation, leading to list-wise deletion.</li>
+  <li>changed the missing_data argument to logical.</li>
+  <li>missing_data = "T" now also works correctly when not using missing = "fiml" estimation, leading to list-wise deletion.</li>
   <li>simulation statistics now includes information as to whether FIML estimation or list-wise deletion was used.</li>
   <li>fixed a bug with the grouping variable in multigroup designs when no empirical data is given</li>
   <li>fixed a bug that forced standard Maximum Likelihood estimation in the simulations.</li>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 ### ezCutoffs 1.0.1
 
 <ul>
-  <li>missing_data = "missing" now also works correctly when not using missing = "fiml" estimation, leading to list-wise deletion.</li> #### not done yet
-  <li>fixed a bug that forced standard Maximum Likelihood estimation.</li>
+  <li>missing_data = "missing" now also works correctly when not using missing = "fiml" estimation, leading to list-wise deletion.</li>
+  <li>simulation statistics now includes information as to whether FIML estimation or list-wise deletion was used.</li>
+  <li>fixed a bug with the grouping variable in multigroup designs when no empirical data is given</li>
+  <li>fixed a bug that forced standard Maximum Likelihood estimation in the simulations.</li>
   <li>fixed a bug with the assignment of missings in the simulated data sets.</li>
 </ul>

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -202,9 +202,9 @@ ezCutoffs <- function(model = NULL,
     progress()
     lavaan::simulateData(pop_model, sample.nobs = group_sizes, group.label = group_labels, skewness = skew, kurtosis = kurt)
   }
-
+  
   group_sizes <- lavaan::lavInspect(fit, what = "nobs")
-
+  
   data_s_list <- vector("list", n_rep)
   data_s_list <- replicate(n_rep, data_generation(), simplify = F)
 
@@ -332,7 +332,12 @@ ezCutoffs <- function(model = NULL,
   if (length(s_est) == 0) {
     s_est <- lavaan::lavInspect(fit_s_list[[1]], what = "options")$estimator
   }
-  simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n), 1, 5))
+  i <- 1
+  while (!(n_sim[1]>0)) {
+    n_sim <- lavaan::lavInspect(fit_s_list[[i]], what = "nobs")
+    i <- i+1
+  }
+  simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n_sim), 1, 5))
   names(simulation_stats) <- c("#Runs", "#Converged", "Estimator", "Alpha", "TotalObservations")
   rownames(simulation_stats) <- ""
 

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -227,7 +227,7 @@ ezCutoffs <- function(model = NULL,
   message("\nModel Fitting\n")
 
   fit_s_list <- vector("list", length = n_rep)
-   estimation <- function(i) {
+   estimation <- function(i, ...) {
      lavaan::sem(model = model, data = data_s_list[[i]], ...)
    }
 
@@ -245,13 +245,13 @@ ezCutoffs <- function(model = NULL,
     cl <- parallel::makeCluster(n_cores)
     doSNOW::registerDoSNOW(cl)
     # foreach loop ------------------------------------------------------------
-    suppressWarnings(fit_s_list <- foreach::foreach(i = 1:n_rep, .options.snow = list(progress = progress)) %dopar% {
-      estimation(i)
-    })
+    fit_s_list <- foreach::foreach(i = 1:n_rep, .options.snow = list(progress = progress)) %dopar% {
+      estimation(i, ...)
+    }
     parallel::stopCluster(cl)
   } else {
     for (i in 1:n_rep) {
-      fit_s <- estimation(i)
+      fit_s <- estimation(i, ...)
       fit_s_list[[i]] <- fit_s
       progress(i)
     }
@@ -327,6 +327,7 @@ ezCutoffs <- function(model = NULL,
   if (length(s_est) == 0) {
     s_est <- lavaan::lavInspect(fit_s_list[[1]], what = "options")$estimator
   }
+  n_sim <- 0                    
   i <- 1
   while (!(n_sim[1]>0)) {
     n_sim <- lavaan::lavInspect(fit_s_list[[i]], what = "nobs")

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -339,7 +339,7 @@ ezCutoffs <- function(model = NULL,
   rownames(simulation_stats) <- ""
   
   dots <- list(...)
-  if (with(dots, exists("missing"))) {
+  if (is.null(dots$missing)==F) {
     simulation_stats[1,6] <- dots$missing
     names(simulation_stats)[6] <- "Missing"
   }

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -355,8 +355,8 @@ ezCutoffs <- function(model = NULL,
   
   dots <- list(...)
   if (is.null(dots$missing)==F) {
-    simulation_stats[1, (length(simulation_stats)+1)] <- dots$missing
-    names(simulation_stats)[(length(simulation_stats)] <- "Missing"
+    simulation_stats[1, (ncol(simulation_stats)+1)] <- dots$missing
+    names(simulation_stats)[(ncol(simulation_stats)] <- "Missing"
   }
 
   # include bootstrapping CI in ouput -------------------------------------------

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -102,8 +102,6 @@ ezCutoffs <- function(model = NULL,
     } else {
       simgroups <- sample(1:length(n_obs), size = sum(n_obs), replace = TRUE, prob = n_obs)
       data <- lavaan::simulateData(model, sample.nobs = n_obs)
-      data[, (ncol(data) + 1)] <- simgroups
-      names(data)[ncol(data)] <- "group"
     }
   }
   

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -356,7 +356,7 @@ ezCutoffs <- function(model = NULL,
   dots <- list(...)
   if (is.null(dots$missing)==F) {
     simulation_stats[1, (ncol(simulation_stats)+1)] <- dots$missing
-    names(simulation_stats)[(ncol(simulation_stats)] <- "Missing"
+    names(simulation_stats)[(ncol(simulation_stats))] <- "Missing"
   }
 
   # include bootstrapping CI in ouput -------------------------------------------

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -352,7 +352,10 @@ ezCutoffs <- function(model = NULL,
   simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n_sim), 1, (4+length(n_sim))))
   names(simulation_stats) <- c("#Runs", "#Converged", "Estimator", "Alpha", "TotalObservations")
   rownames(simulation_stats) <- ""
-  
+  if (length(n_sim) > 1) {
+    names(simulation_stats)[5:(4+length(n_sim))] <- c(paste0('n_', group_labels))
+  }
+                      
   dots <- list(...)
   if (is.null(dots$missing)==F) {
     simulation_stats[1, (ncol(simulation_stats)+1)] <- dots$missing

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -166,6 +166,7 @@ ezCutoffs <- function(model = NULL,
   groups_var <- lavaan::lavInspect(fit, what = "group")
   n_groups <- lavaan::lavInspect(fit, what = "ngroups")
   group_labels <- lavaan::lavInspect(fit, what = "group.label")
+  dots <- list(...)
   # stop if grouping variable wiht only one level has been selected
   if ((length(groups_var) > 0) & n_groups < 2) {
     stop("Less than 2 levels in the defined grouping variable.")
@@ -219,6 +220,24 @@ ezCutoffs <- function(model = NULL,
     var_table <- lavaan::varTable(fit)
 
     missings <- apply(data, 2, function(x) which(is.na(x)))
+    n_var <- nrow(var_table)
+    
+    if (is.null(dots$missing)==T) {
+      dots$missing <- "listwise"
+    }
+    if (dots$missing == "fiml") { #full misses
+      misses <- as.integer(names(which(table(unlist(missings)) == n_var)))
+      } else { # listwise, any misses
+      misses <- as.integer(names(table(unlist(missings))))
+    }
+    
+    for (i in 1:n_var) {
+          pos <- missings[[i]] %in% misses
+          missings[[i]] <- missings[[i]][!pos]
+    }
+                      
+                  
+                      
     for (i in 1:n_rep) {
       for (v in 1:nrow(var_table)) {
         data_s_list[[i]][missings[[v]], v] <- NA # use same missing template as given data

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -349,7 +349,7 @@ ezCutoffs <- function(model = NULL,
     n_sim <- lavaan::lavInspect(fit_s_list[[i]], what = "nobs")
     i <- i+1
   }
-  simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n_sim), 1, (4+lengt(n_sim))))
+  simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n_sim), 1, (4+length(n_sim))))
   names(simulation_stats) <- c("#Runs", "#Converged", "Estimator", "Alpha", "TotalObservations")
   rownames(simulation_stats) <- ""
   

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -212,6 +212,7 @@ ezCutoffs <- function(model = NULL,
   }
 
   # add missings if requested
+  if (sum(is.na(data))==0) {missing_data="complete"} #check that there actually is missing data, if not switch to complete
   if (missing_data == "missing") {
     var_table <- lavaan::varTable(fit)
 
@@ -336,6 +337,7 @@ ezCutoffs <- function(model = NULL,
   simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n_sim), 1, 5))
   names(simulation_stats) <- c("#Runs", "#Converged", "Estimator", "Alpha", "TotalObservations")
   rownames(simulation_stats) <- ""
+  
 
 
   # include bootstrapping CI in ouput -------------------------------------------

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -12,7 +12,7 @@
 #' @param fit_indices Character vector, containing a selection of fit indices for which to calculate cutoff values. Only measures produced by \link[lavaan]{fitMeasures} can be chosen.
 #' @param alpha_level Type I-error rate for the generated cutoff values: Between 0 and 1; 0.05 per default.
 #' @param normality Specify distributional assumptions for the simulated data: Either \code{"assumed"} for normal distribution, or \code{"empirical"} for distributions based on the skewness and kurtosis values of the empirical data.
-#' @param missing_data Specify handling of missing values: Either \code{"complete"} to generate complete data sets, or \code{"missing"} to generate data with the same number of missing values on the observed variables as in the empirical data.
+#' @param missing_data Specify handling of missing values: Either \code{FALSE} to generate complete data sets, or \code{TRUE} to generate data with the same number of missing values on the observed variables as in the empirical data.
 #' @param bootstrapped_ci Specify whether a boostrapped confidence interval for the empirical model fit statistics should be drawn; default = FALSE.
 #' @param n_boot Number of replications in bootstrap for confidence intervalls for empirical model fit statistics.
 #' @param boot_alpha Type I-error rate choosen for the boostrap-confidence interval: Between 0 and 1; 0.05 per default.
@@ -23,7 +23,7 @@
 #' @details
 #' \code{model} is expected in standard lavaan nomenclature. The typical pre-multiplication mechanism is supported, with the exception of vectors (see Examples). Multigroup models should instead be specified using the \code{group} argument. \cr\cr
 #' If \code{data} is not specified, the program will generate data based on the given \code{model} and \code{n_obs}. A numeric vector would signify multiple groups and \code{group} needs to be set to "group" in this case. Otherwise, \code{n_obs} is disregarded. \cr\cr
-#' \code{missing_data = "missing"} assumes that the data is missing completely at random. That, is missings should not be distributed unevenly in multigroup models, for instance.\cr\cr
+#' \code{missing_data = TRUE} assumes that the data is missing completely at random. That, is missings should not be distributed unevenly in multigroup models, for instance.\cr\cr
 #' \code{bootstrapped_ci = "TRUE"} Returns a nonparametric bootstrap confidence interval that quantifies the uncertainty within a data set with regard to the empirical fit indices. Larger sample sizes should, under ideal circumstances, have smaller confidence intervals. For more information see, e.g., Efron (1981; 1987). Bootstrapping uses the \code{library(boot)} and (if available) several CPUs to compute the confidence intervals via \code{snow}. \cr\cr
 #' \code{...} allows the user to pass lavaan arguments to the model fitting procedure. Options include multigroup, repeated measures, growth curve, and multilevel models.
 #'
@@ -79,7 +79,7 @@ ezCutoffs <- function(model = NULL,
                       fit_indices = c("chisq", "cfi", "tli", "rmsea", "srmr"),
                       alpha_level = 0.05,
                       normality = "assumed",
-                      missing_data = "complete",
+                      missing_data = FALSE,
                       bootstrapped_ci = FALSE,
                       n_boot = 1000,
                       boot_alpha = 0.05,
@@ -212,8 +212,10 @@ ezCutoffs <- function(model = NULL,
   }
 
   # add missings if requested
-  if (sum(is.na(data))==0) {missing_data="complete"} #check that there actually is missing data, if not switch to complete
-  if (missing_data == "missing") {
+  if (sum(is.na(data))==0) {
+    missing_data <- F
+  } #check that there actually is missing data, if not switch to complete
+  if (missing_data == T) {
     var_table <- lavaan::varTable(fit)
 
     missings <- apply(data, 2, function(x) which(is.na(x)))

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -349,14 +349,14 @@ ezCutoffs <- function(model = NULL,
     n_sim <- lavaan::lavInspect(fit_s_list[[i]], what = "nobs")
     i <- i+1
   }
-  simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n_sim), 1, 5))
+  simulation_stats <- data.frame(matrix(c(n_rep, n_conv, s_est, alpha_level, n_sim), 1, (4+lengt(n_sim))))
   names(simulation_stats) <- c("#Runs", "#Converged", "Estimator", "Alpha", "TotalObservations")
   rownames(simulation_stats) <- ""
   
   dots <- list(...)
   if (is.null(dots$missing)==F) {
-    simulation_stats[1,6] <- dots$missing
-    names(simulation_stats)[6] <- "Missing"
+    simulation_stats[1, (length(simulation_stats)+1)] <- dots$missing
+    names(simulation_stats)[(length(simulation_stats)] <- "Missing"
   }
 
   # include bootstrapping CI in ouput -------------------------------------------

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -97,12 +97,7 @@ ezCutoffs <- function(model = NULL,
 
   # Create data if none is given
   if (is.null(data)) {
-    if (length(n_obs) == 1) {
-      data <- lavaan::simulateData(model, sample.nobs = n_obs)
-    } else {
-      simgroups <- sample(1:length(n_obs), size = sum(n_obs), replace = TRUE, prob = n_obs)
-      data <- lavaan::simulateData(model, sample.nobs = n_obs)
-    }
+    data <- lavaan::simulateData(model, sample.nobs = n_obs)
   }
   
   fit <- lavaan::sem(model = model, data = data,  ...) 

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -69,8 +69,6 @@
 #' plot(out)
 #' @seealso \code{\link{compareFit}}
 
-
-
 #' @export
 ezCutoffs <- function(model = NULL,
                       data = NULL,
@@ -88,7 +86,6 @@ ezCutoffs <- function(model = NULL,
                       ...) {
 
   # empirical fit-----------------------------------------------------------------
-
 
   # Occurences of c( in model
   if (grepl("\\c\\(", model) == T) {
@@ -234,9 +231,7 @@ ezCutoffs <- function(model = NULL,
     for (i in 1:n_var) {
           pos <- missings[[i]] %in% misses
           missings[[i]] <- missings[[i]][!pos]
-    }
-                      
-                  
+    }                                
                       
     for (i in 1:n_rep) {
       for (v in 1:nrow(var_table)) {
@@ -318,7 +313,6 @@ ezCutoffs <- function(model = NULL,
     "nnfi.scaled", "nnfi.robust", "rfi.scaled", "nfi.scaled", "ifi.scaled", "rni.scaled", "rni.robust", "logl", "unrestricted.logl", "gfi",
     "agfi", "pgfi", "mfi", "rmsea.pvalue", "rmsea.pvalue.scaled", "rmsea.pvalue.robust", "cn_05", "cn_01"
   )
-
 
   for (i in 1:length_di) {
     if ((fit_indices[i] %in% high_cut_index) == T) {

--- a/R/ezCutoffs.R
+++ b/R/ezCutoffs.R
@@ -338,7 +338,11 @@ ezCutoffs <- function(model = NULL,
   names(simulation_stats) <- c("#Runs", "#Converged", "Estimator", "Alpha", "TotalObservations")
   rownames(simulation_stats) <- ""
   
-
+  dots <- list(...)
+  if (with(dots, exists("missing"))) {
+    simulation_stats[1,6] <- dots$missing
+    names(simulation_stats)[6] <- "Missing"
+  }
 
   # include bootstrapping CI in ouput -------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ install.packages("devtools")
 devtools::install_github("bschmalbach/ezCutoffs")
 ```
 ___________________________________
-If you encounter any errors, bugs, or otherwise unexpected results, please give us a heads-up at [github](https://github.com/bschmalbach/ezCutoffs/issues) or at bjarne.schmalbach@gmail.com.
+If you encounter any errors, bugs, or otherwise unexpected results, please give us a heads-up at [GitHub](https://github.com/bschmalbach/ezCutoffs/issues) or at bjarne.schmalbach@gmail.com.


### PR DESCRIPTION
Removed duplicate lines of code for missing_data = "missing" which forced fiml estimation.
They can instead just be passed via ...

Still need to fix the warning given when n_cores>1,
which is currently suppressed.
I'm looking into solutions that suggest retrieving ... beforehand.